### PR TITLE
Fixed multiple legend issue (sorta)

### DIFF
--- a/code/Species_ExpTakeAdults_Leaflet.R
+++ b/code/Species_ExpTakeAdults_Leaflet.R
@@ -182,8 +182,9 @@ leaf_ExpTake_adults <- leaflet(final.spatial) %>%
             group = "Coho", position = "bottomleft",
             className = "info legend Coho") %>% 
   addLayersControl(
-    baseGroups = c("Chinook", "Steelhead",
-                   "Green Sturgeon", "Coho")) %>% 
+    overlayGroups = c("Chinook", "Steelhead",
+                   "Green Sturgeon", "Coho"),
+    options = layersControlOptions(collapsed = F)) %>% 
   htmlwidgets::onRender("
       function(el, x) {
          var updateLegend = function () {

--- a/code/Species_ExpTakeJuveniles_Leaflet.R
+++ b/code/Species_ExpTakeJuveniles_Leaflet.R
@@ -181,8 +181,9 @@ leaf_ExpTake_juveniles <- leaflet(final.spatial) %>%
             group = "Coho", position = "bottomleft",
             className = "info legend Coho") %>% 
   addLayersControl(
-    baseGroups = c("Chinook", "Steelhead",
-                   "Green Sturgeon", "Coho")) %>% 
+    overlayGroups = c("Chinook", "Steelhead",
+                   "Green Sturgeon", "Coho"),
+    options = layersControlOptions(collapsed = F)) %>% 
   htmlwidgets::onRender("
       function(el, x) {
          var updateLegend = function () {


### PR DESCRIPTION
- Changed from baseGroups to overlayGroups in Leaflet call
- allows for species to be plotted on top of each other (undesirable)
- allows for only viewing the pertinent legend when viewing each species (desirable)